### PR TITLE
Xenon Pre-Commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,6 +140,22 @@ repos:
         args: [
           "--line-length=79",
         ]
+###############################################################################
+# XENON CODE COMPLEXITY
+###############################################################################
+-   repo: https://github.com/rubik/xenon
+    rev: v0.9.0
+    hooks:
+    -   id: xenon
+        args: [
+            # threshold for the average complexity
+            # (across all the codebase).
+            "--max-absolute=B",
+            # threshold for modules complexity.
+            "--max-modules=B",
+            # absolute threshold for block complexity.
+            "--max-average=A"
+        ]
 ################################################################################
 # UV PACKAGE AND DEPENDENCY MANAGEMENT
 ################################################################################


### PR DESCRIPTION
This PR adds the `xenon` `pre-commit` hook to `.pre-commit-config.yaml`.

